### PR TITLE
Fixed missing error message when there was an error in the with state…

### DIFF
--- a/Backend/app/email/emailProxy.py
+++ b/Backend/app/email/emailProxy.py
@@ -1,6 +1,7 @@
 import email
 import imaplib
 import time
+import traceback
 
 import handle_mail as hm
 import smtp_conn as sm
@@ -106,11 +107,16 @@ class EmailProxy:
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         close the connection to the imap server
-        :param exc_type:
-        :param exc_val:
-        :param exc_tb:
+        :param exc_type: exception_type
+        :param exc_val: exception_value
+        :param exc_tb: traceback
         :return:
         """
+        if exc_type:
+            if exc_type != KeyboardInterrupt:
+                logger.error("Error: ", exc_info=(exc_type, exc_val, exc_tb))
+            else:
+                logger.info("Keyboard Interrupt, Application is shutting down")
         self.imap.close()
         self.imap.logout()
         self.smtp.smtp.quit()


### PR DESCRIPTION
We got no information about why the proxy shutdown. This is fixed now. Screenshot shows the bug before the fix.
![Screenshot 2024-01-31 134120](https://github.com/amosproj/amos2023ws01-ticket-chat-ai/assets/111361137/e06a8425-4559-4bf4-9989-dd92b097f332)
